### PR TITLE
fix: python pre-commit checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,7 +47,7 @@ repos:
       - id: detect-private-key
 
   - repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
       - id: black
 


### PR DESCRIPTION
Fixing python pre-commits. For a problem description and fix see [Stackoverflow](https://stackoverflow.com/questions/71673404/importerror-cannot-import-name-unicodefun-from-click)
