### PR TITLE
feat/add a commit message linter

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["@commitlint/config-conventional"]
+}

--- a/.devcontainer/post-create-setup.sh
+++ b/.devcontainer/post-create-setup.sh
@@ -2,6 +2,7 @@
 
 #install pre-commit in the git repo
 pre-commit install --install-hooks
+pre-commit install --hook-type commit-msg
 
 #generate python classes from protobuf messages
 mkdir -p build/gRPC

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,7 @@
 #
 # See https://github.com/pre-commit/pre-commit
 
+default_stages: [commit]
 repos:
   # Standard hooks
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -114,6 +115,13 @@ repos:
     rev: "v2.6.2" # Use the sha / tag you want to point at
     hooks:
       - id: prettier
+
+  - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
+    rev: "v8.0.0"
+    hooks:
+      - id: commitlint
+        stages: [commit-msg]
+        additional_dependencies: ["@commitlint/config-conventional"]
 
   - repo: https://github.com/pre-commit/mirrors-eslint
     rev: "v8.16.0" # Use the sha / tag you want to point at

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@
 repos:
   # Standard hooks
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.2.0
     hooks:
       - id: check-added-large-files
       - id: check-case-conflict
@@ -104,17 +104,19 @@ repos:
     rev: v2.2.0
     hooks:
       - id: seed-isort-config
+
   - repo: https://github.com/pre-commit/mirrors-isort
     rev: v5.10.1
     hooks:
       - id: isort
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: "v2.6.1" # Use the sha / tag you want to point at
+    rev: "v2.6.2" # Use the sha / tag you want to point at
     hooks:
       - id: prettier
+
   - repo: https://github.com/pre-commit/mirrors-eslint
-    rev: "v8.12.0" # Use the sha / tag you want to point at
+    rev: "v8.16.0" # Use the sha / tag you want to point at
     hooks:
       - id: eslint
         files: \.([jt]sx?|vue)$ # *.js, *.jsx, *.ts, *.tsx and *.vue


### PR DESCRIPTION
Added commit linter with pre-commit hook that checks for [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). 

- [commitlint-pre-commit-hook](https://github.com/alessandrojcm/commitlint-pre-commit-hook)
- [commitlint](https://github.com/conventional-changelog/commitlint)

"Merge ..." commits are ignored!

Closes #75 