### PR TITLE
feat/widget manager

### DIFF
--- a/vue/src/assets/base.css
+++ b/vue/src/assets/base.css
@@ -2,12 +2,14 @@
 @import "vue-advanced-cropper/dist/style.css";
 
 /* TAILWINDCSS */
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
 @layer utilities {
   /* SENSOR MAP ICON */
+
   .sensor-icon {
     width: 25px;
     height: 25px;
@@ -27,12 +29,19 @@
     /* TODO: discuss color, add to tailwind colors */
   }
 
+  /* ----------- */
+
   /* SENSOR TABLE */
+
   .sensor-row-active td {
     background-color: #bbe784 !important;
     /* TODO: discuss color, add to tailwind colors */
   }
+
+  /* ----------- */
 }
+
+/* ----------- */
 
 :root {
   /* color light mode */
@@ -80,6 +89,7 @@
 } */
 
 /* MAP */
+
 #map {
   position: absolute;
   height: 100%;
@@ -89,7 +99,42 @@
   left: 0;
 }
 
+/* ----------- */
+
+/* WIDGET */
+
+.widget {
+  @apply drop-shadow rounded-md bg-background py-0;
+}
+
+.widget span {
+  @apply font-bold text-[#707070] px-4;
+}
+
+.widget-content.q-position-engine {
+  @apply rounded-lg mt-0.5 !important;
+}
+
+.widget .q-field__native,
+.widget .q-field__control,
+.widget-content .q-item {
+  @apply min-h-min !important;
+}
+
+.widget-content .q-item {
+  @apply bg-white;
+  /* TODO adjust color */
+}
+
+.widget-content-selected {
+  @apply text-black !important;
+  /* TODO adjust color */
+}
+
+/* ----------- */
+
 /* SENSOR TABLE */
+
 .sensor-table thead th {
   @apply uppercase font-bold;
   color: #6b7280;
@@ -117,7 +162,10 @@
   @apply border-none;
 }
 
+/* ----------- */
+
 /* CROPS TABLE */
+
 .crops-table thead th:first-child {
   border-top-left-radius: 1rem;
 }
@@ -165,4 +213,5 @@ tbody tr:nth-child(even) {
 .crops-table tbody tr:hover {
   background-color: #e5e7eb;
 }
+
 /* ----------- */

--- a/vue/src/components/header/HeaderBar.vue
+++ b/vue/src/components/header/HeaderBar.vue
@@ -7,6 +7,10 @@
       <div class="flex items-center">
         <!--TODO: Add Quasar components (Button, Avatar)-->
         <div class="mr-3">
+          <widget-comp :options="options" label="widgets"></widget-comp>
+        </div>
+
+        <div class="mr-3">
           <a href="#" class="block relative">
             <svg
               class="fill-primary"
@@ -49,6 +53,27 @@
 </template>
 
 <script setup lang="ts">
+import WidgetComp from "@/components/header/widget/WidgetComp.vue";
+import type { WidgetOption } from "@/types/widgetOption";
+
+const options: WidgetOption[] = [
+  {
+    label: "weather",
+    name: "weather",
+  },
+  {
+    label: "soil parameter",
+    name: "soil-parameter",
+  },
+  {
+    label: "notifications",
+    name: "notifications",
+  },
+  {
+    label: "garden",
+    name: "garden",
+  },
+];
 defineProps<{
   title: string;
 }>();

--- a/vue/src/components/header/HeaderBar.vue
+++ b/vue/src/components/header/HeaderBar.vue
@@ -7,7 +7,11 @@
       <div class="flex items-center">
         <!--TODO: Add Quasar components (Button, Avatar)-->
         <div class="mr-3">
-          <widget-comp :options="options" label="widgets"></widget-comp>
+          <widget-comp
+            :widgetOptions="widgetOptions"
+            :storeOptions="storeOptions"
+            label="widgets"
+          ></widget-comp>
         </div>
 
         <div class="mr-3">
@@ -54,27 +58,11 @@
 
 <script setup lang="ts">
 import WidgetComp from "@/components/header/widget/WidgetComp.vue";
-import type { WidgetOption } from "@/types/widgetOption";
+import type { WidgetOption, StoreOption } from "@/types/widgetOption";
 
-const options: WidgetOption[] = [
-  {
-    label: "weather",
-    name: "weather",
-  },
-  {
-    label: "soil parameter",
-    name: "soil-parameter",
-  },
-  {
-    label: "notifications",
-    name: "notifications",
-  },
-  {
-    label: "garden",
-    name: "garden",
-  },
-];
 defineProps<{
   title: string;
+  widgetOptions: WidgetOption[];
+  storeOptions: StoreOption[];
 }>();
 </script>

--- a/vue/src/components/header/widget/WidgetComp.vue
+++ b/vue/src/components/header/widget/WidgetComp.vue
@@ -3,7 +3,7 @@
     dir="rtl"
     class="widget"
     v-model="widgetModel"
-    :options="options"
+    :options="widgetOptions"
     :display-value="label"
     hide-dropdown-icon
     multiple
@@ -16,6 +16,8 @@
     option-label="label"
     map-options
     emit-value
+    @add="add"
+    @remove="remove"
   >
     <!-- TODO: check menu-anchor & menu-self -> when the website reloads, you can see the position changes -->
     <template v-slot:option="scope">
@@ -38,14 +40,30 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from "vue";
-import type { QSelect } from "quasar";
-import type { WidgetOption } from "@/types/widgetOption";
+import { ref, onMounted } from "vue";
+import type { WidgetOption, StoreOption } from "@/types/widgetOption";
+import { userStore } from "@/stores/userStore";
 
-const widgetModel = ref<InstanceType<typeof QSelect> | null>(null);
+const { addOption, removeOption } = userStore();
 
-defineProps<{
+let widgetModel = ref<StoreOption[]>([]);
+
+const props = defineProps<{
   label: string;
-  options: WidgetOption[];
+  widgetOptions: WidgetOption[];
+  storeOptions: StoreOption[];
 }>();
+
+onMounted(() => {
+  widgetModel.value = props.storeOptions;
+});
+
+//TODO: change type
+function add(item: any): void {
+  addOption(item.value);
+}
+//TODO: change type
+function remove(item: any): void {
+  removeOption(item.value);
+}
 </script>

--- a/vue/src/components/header/widget/WidgetComp.vue
+++ b/vue/src/components/header/widget/WidgetComp.vue
@@ -1,0 +1,51 @@
+<template>
+  <q-select
+    dir="rtl"
+    class="widget"
+    v-model="widgetModel"
+    :options="options"
+    :display-value="label"
+    hide-dropdown-icon
+    multiple
+    borderless
+    popup-content-class="widget-content"
+    menu-self="top middle"
+    menu-anchor="bottom left"
+    options-selected-class="widget-content-selected"
+    option-value="name"
+    option-label="label"
+    map-options
+    emit-value
+  >
+    <!-- TODO: check menu-anchor & menu-self -> when the website reloads, you can see the position changes -->
+    <template v-slot:option="scope">
+      <q-item v-bind="scope.itemProps">
+        <q-item-section>
+          <q-item-label v-html="scope.opt.label"></q-item-label>
+        </q-item-section>
+        <q-item-section avatar>
+          <!-- TODO: adjust color -->
+          <q-icon
+            v-if="scope.selected"
+            name="check"
+            class="text-[#707070]"
+          ></q-icon>
+          <q-icon v-else name="none"></q-icon>
+        </q-item-section>
+      </q-item>
+    </template>
+  </q-select>
+</template>
+
+<script setup lang="ts">
+import { ref } from "vue";
+import type { QSelect } from "quasar";
+import type { WidgetOption } from "@/types/widgetOption";
+
+const widgetModel = ref<InstanceType<typeof QSelect> | null>(null);
+
+defineProps<{
+  label: string;
+  options: WidgetOption[];
+}>();
+</script>

--- a/vue/src/stores/userStore.ts
+++ b/vue/src/stores/userStore.ts
@@ -1,0 +1,24 @@
+import { defineStore } from "pinia";
+import type { StoreOption } from "@/types/widgetOption";
+
+// TODO: move to types/store
+interface userStore {
+  options: StoreOption[];
+}
+
+export const userStore = defineStore({
+  id: "userStore",
+  state: (): userStore => ({
+    options: ["weather", "garden", "soil-parameter"], //TODO: delete later
+  }),
+  getters: {
+    getOptions(state: userStore): StoreOption[] {
+      return state.options;
+    },
+  },
+  actions: {
+    async updateOptions(): Promise<void> {
+      //TODO: send options to API
+    },
+  },
+});

--- a/vue/src/stores/userStore.ts
+++ b/vue/src/stores/userStore.ts
@@ -9,7 +9,15 @@ interface userStore {
 export const userStore = defineStore({
   id: "userStore",
   state: (): userStore => ({
-    options: ["weather", "garden", "soil-parameter"], //TODO: delete later
+    options: [
+      "weather",
+      "garden-map",
+      "soil-parameter",
+      "crops-table",
+      "crops-map",
+      "3d-table",
+      "3d-map",
+    ], //TODO: delete later
   }),
   getters: {
     getOptions(state: userStore): StoreOption[] {

--- a/vue/src/stores/userStore.ts
+++ b/vue/src/stores/userStore.ts
@@ -1,30 +1,46 @@
 import { defineStore } from "pinia";
+import type { User } from "@/types/user";
 import type { StoreOption } from "@/types/widgetOption";
 
 // TODO: move to types/store
 interface userStore {
-  options: StoreOption[];
+  user: User;
 }
 
 export const userStore = defineStore({
   id: "userStore",
   state: (): userStore => ({
-    options: [
-      "weather",
-      "garden-map",
-      "soil-parameter",
-      "crops-table",
-      "crops-map",
-      "3d-table",
-      "3d-map",
-    ], //TODO: delete later
+    user: {
+      settings: {
+        widgetOptions: [
+          "weather",
+          "garden-map",
+          "soil-parameter",
+          "crops-table",
+          "crops-map",
+          "3d-table",
+          "3d-map",
+        ], //TODO: delete later
+      },
+    },
   }),
   getters: {
     getOptions(state: userStore): StoreOption[] {
-      return state.options;
+      return state.user.settings.widgetOptions;
     },
   },
   actions: {
+    addOption(storeOption: StoreOption): void {
+      this.user.settings.widgetOptions.push(storeOption);
+      this.updateOptions();
+    },
+    removeOption(storeOption: StoreOption): void {
+      const index = this.user.settings.widgetOptions.indexOf(storeOption, 0);
+      if (index > -1) {
+        this.user.settings.widgetOptions.splice(index, 1);
+      }
+      this.updateOptions();
+    },
     async updateOptions(): Promise<void> {
       //TODO: send options to API
     },

--- a/vue/src/types/user.ts
+++ b/vue/src/types/user.ts
@@ -1,0 +1,9 @@
+import type { StoreOption } from "@/types/WidgetOption";
+
+export interface User {
+  settings: Settings;
+}
+
+export interface Settings {
+  widgetOptions: StoreOption[];
+}

--- a/vue/src/types/widgetOption.ts
+++ b/vue/src/types/widgetOption.ts
@@ -2,3 +2,8 @@ export interface WidgetOption {
   name: string;
   label: string;
 }
+export type StoreOption =
+  | "weather"
+  | "soil-parameter"
+  | "notifications"
+  | "garden";

--- a/vue/src/types/widgetOption.ts
+++ b/vue/src/types/widgetOption.ts
@@ -1,9 +1,45 @@
 export interface WidgetOption {
-  name: string;
   label: string;
+  name: string;
 }
-export type StoreOption =
-  | "weather"
-  | "soil-parameter"
-  | "notifications"
-  | "garden";
+
+export const widgetOptions = {
+  weather: {
+    label: "weather",
+    name: "weather",
+  },
+  soilParameter: {
+    label: "soil parameter",
+    name: "soil-parameter",
+  },
+  notification: {
+    label: "notifications",
+    name: "notifications",
+  },
+  gardenMap: {
+    label: "garden map",
+    name: "garden-map",
+  },
+  cropsTable: {
+    label: "crops table",
+    name: "crops-table",
+  },
+  cropsMap: {
+    label: "crops map",
+    name: "crops-map",
+  },
+  "3dTable": {
+    label: "3D table",
+    name: "3d-table",
+  },
+  "3dMap": {
+    label: "3D map",
+    name: "3d-map",
+  },
+} as const;
+
+//type of widgetOptions keys
+type widgetOptionsKeys = keyof typeof widgetOptions;
+
+//type of widgetOptions names
+export type StoreOption = typeof widgetOptions[widgetOptionsKeys]["name"];

--- a/vue/src/types/widgetOption.ts
+++ b/vue/src/types/widgetOption.ts
@@ -1,0 +1,4 @@
+export interface WidgetOption {
+  name: string;
+  label: string;
+}

--- a/vue/src/types/widgetOption.ts
+++ b/vue/src/types/widgetOption.ts
@@ -28,11 +28,11 @@ export const widgetOptions = {
     label: "crops map",
     name: "crops-map",
   },
-  "3dTable": {
+  crops3dTable: {
     label: "3D table",
     name: "3d-table",
   },
-  "3dMap": {
+  crops3dMap: {
     label: "3D map",
     name: "3d-map",
   },

--- a/vue/src/views/Crops3dView.vue
+++ b/vue/src/views/Crops3dView.vue
@@ -30,8 +30,8 @@ import CropsMap from "@/components/CropsMap.vue";
 
 const storeOptions: Ref<StoreOption[]> = storeToRefs(userStore()).getOptions;
 const widgetOptions3D: WidgetOption[] = [
-  widgetOptions["3dTable"],
-  widgetOptions["3dMap"],
+  widgetOptions.crops3dTable,
+  widgetOptions.crops3dMap,
 ];
 
 onMounted(() => {

--- a/vue/src/views/Crops3dView.vue
+++ b/vue/src/views/Crops3dView.vue
@@ -1,21 +1,39 @@
 <template>
-  <header-bar title="3D"></header-bar>
+  <header-bar
+    title="3D"
+    :widgetOptions="widgetOptions3D"
+    :storeOptions="storeOptions"
+  ></header-bar>
   <div class="row p-6">
-    <div class="col-4">
+    <div v-if="storeOptions.indexOf('3d-table') > -1" class="col-4">
       <crops-table title="Plants" :visibleColumns="columns"></crops-table>
     </div>
-    <div class="col-8 pl-2">
+    <div v-if="storeOptions.indexOf('3d-map') > -1" class="col-8 pl-2">
       <crops-map></crops-map>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
+import { onMounted, type Ref } from "vue";
+import { storeToRefs } from "pinia";
+import { cropsStore } from "@/stores/cropsStore";
+import { userStore } from "@/stores/userStore";
+import {
+  widgetOptions,
+  type StoreOption,
+  type WidgetOption,
+} from "@/types/widgetOption";
 import HeaderBar from "@/components/header/HeaderBar.vue";
 import CropsTable from "../components/CropsTable.vue";
 import CropsMap from "@/components/CropsMap.vue";
-import { cropsStore } from "@/stores/cropsStore";
-import { onMounted } from "vue";
+
+const storeOptions: Ref<StoreOption[]> = storeToRefs(userStore()).getOptions;
+const widgetOptions3D: WidgetOption[] = [
+  widgetOptions["3dTable"],
+  widgetOptions["3dMap"],
+];
+
 onMounted(() => {
   cropsStore().loadDataFromApi();
 });

--- a/vue/src/views/Crops3dView.vue
+++ b/vue/src/views/Crops3dView.vue
@@ -11,7 +11,7 @@
 </template>
 
 <script setup lang="ts">
-import HeaderBar from "@/components/HeaderBar.vue";
+import HeaderBar from "@/components/header/HeaderBar.vue";
 import CropsTable from "../components/CropsTable.vue";
 import CropsMap from "@/components/CropsMap.vue";
 import { cropsStore } from "@/stores/cropsStore";

--- a/vue/src/views/CropsView.vue
+++ b/vue/src/views/CropsView.vue
@@ -22,7 +22,7 @@
 import CropsTable from "../components/CropsTable.vue";
 import { onMounted } from "vue";
 import { cropsStore } from "@/stores/cropsStore";
-import HeaderBar from "@/components/HeaderBar.vue";
+import HeaderBar from "@/components/header/HeaderBar.vue";
 import CropsMap from "@/components/CropsMap.vue";
 onMounted(() => {
   cropsStore().loadDataFromApi();

--- a/vue/src/views/CropsView.vue
+++ b/vue/src/views/CropsView.vue
@@ -7,23 +7,41 @@
   <!-- <div class="px-3 py-5 text-h2 text-primary_hover">
     Crops
   </div> -->
-  <header-bar title="Crops"></header-bar>
+  <header-bar
+    title="Crops"
+    :widgetOptions="widgetOptionsCrops"
+    :storeOptions="storeOptions"
+  ></header-bar>
   <div class="row p-6">
-    <div class="col-8">
+    <div v-if="storeOptions.indexOf('crops-table') > -1" class="col-8">
       <crops-table title="Overview" :visibleColumns="columns"></crops-table>
     </div>
-    <div class="col-4 pl-2">
+    <div v-if="storeOptions.indexOf('crops-map') > -1" class="col-4 pl-2">
       <crops-map></crops-map>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import CropsTable from "../components/CropsTable.vue";
-import { onMounted } from "vue";
+import { onMounted, type Ref } from "vue";
+import { storeToRefs } from "pinia";
 import { cropsStore } from "@/stores/cropsStore";
+import { userStore } from "@/stores/userStore";
+import {
+  widgetOptions,
+  type StoreOption,
+  type WidgetOption,
+} from "@/types/widgetOption";
+import CropsTable from "@/components/CropsTable.vue";
 import HeaderBar from "@/components/header/HeaderBar.vue";
 import CropsMap from "@/components/CropsMap.vue";
+
+const storeOptions: Ref<StoreOption[]> = storeToRefs(userStore()).getOptions;
+const widgetOptionsCrops: WidgetOption[] = [
+  widgetOptions.cropsTable,
+  widgetOptions.cropsMap,
+];
+
 onMounted(() => {
   cropsStore().loadDataFromApi();
 });

--- a/vue/src/views/DashboardView.vue
+++ b/vue/src/views/DashboardView.vue
@@ -68,7 +68,7 @@ import WeatherComp from "@/components/Weather/WeatherComp.vue";
 // import SensorComp from "@/components/SensorComp.vue";
 import SensorComp from "@/components/SensorCompQuasar.vue";
 import GardenMap from "@/components/GardenMap.vue";
-import HeaderBar from "@/components/HeaderBar.vue";
+import HeaderBar from "@/components/header/HeaderBar.vue";
 import { ref } from "vue";
 
 import { storeToRefs } from "pinia";

--- a/vue/src/views/DashboardView.vue
+++ b/vue/src/views/DashboardView.vue
@@ -1,10 +1,17 @@
 <template>
-  <header-bar title="Dashboard"></header-bar>
+  <header-bar
+    title="Dashboard"
+    :widgetOptions="widgetOptionsDashboard"
+    :storeOptions="storeOptions"
+  ></header-bar>
   <div class="grid grid-cols-3 gap-4 place-items-stretch h-fit p-6">
-    <div>
+    <div v-if="storeOptions.indexOf('weather') > -1">
       <weather-comp></weather-comp>
     </div>
-    <div class="col-span-2 row-span-2">
+    <div
+      v-if="storeOptions.indexOf('garden-map') > -1"
+      class="col-span-2 row-span-2"
+    >
       <div class="h-full">
         <garden-map
           ref="gardenMapRef"
@@ -14,7 +21,7 @@
         ></garden-map>
       </div>
     </div>
-    <div>
+    <div v-if="storeOptions.indexOf('soil-parameter') > -1">
       <sensor-comp
         ref="sensorCompRef"
         :sensors="sensors"
@@ -60,24 +67,31 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted } from "vue";
-import { weatherDataStore } from "../stores/weatherDataStore";
-import { sensorStore } from "../stores/sensorStore";
-
+import { ref, type Ref } from "vue";
+import { storeToRefs } from "pinia";
+import { sensorStore } from "@/stores/sensorStore";
+import { userStore } from "@/stores/userStore";
+import type { Sensor } from "@/types/sensor";
+import {
+  widgetOptions,
+  type StoreOption,
+  type WidgetOption,
+} from "@/types/widgetOption";
 import WeatherComp from "@/components/Weather/WeatherComp.vue";
-// import SensorComp from "@/components/SensorComp.vue";
 import SensorComp from "@/components/SensorCompQuasar.vue";
 import GardenMap from "@/components/GardenMap.vue";
 import HeaderBar from "@/components/header/HeaderBar.vue";
-import { ref } from "vue";
-
-import { storeToRefs } from "pinia";
-import type { Ref } from "vue";
-import type { Sensor } from "@/types/sensor";
 
 const sensors: Ref<Sensor[]> = storeToRefs(sensorStore()).getSensors;
+const storeOptions: Ref<StoreOption[]> = storeToRefs(userStore()).getOptions;
 const gardenMapRef = ref<InstanceType<typeof GardenMap> | null>(null);
 const sensorCompRef = ref<InstanceType<typeof SensorComp> | null>(null);
+const widgetOptionsDashboard: WidgetOption[] = [
+  widgetOptions.weather,
+  widgetOptions.soilParameter,
+  widgetOptions.gardenMap,
+  widgetOptions.notification,
+];
 
 // Sensor - Map interaction
 function mapSensorEnter(sensorId: number): void {


### PR DESCRIPTION
- implemented `WidgetComp.vue`
- added `User`, `Settings`, `WidgetOption` and `StoreOption` types
- created an `userStore` to manage the options
- components can now be marked as **visible** or **not visible**

**known bugs:**
- widget content jumps to its position on the first load
- components are not optimized to be hidden or placed elsewhere

![Screenshot 2022-06-17 112345](https://user-images.githubusercontent.com/87453514/174271239-ea029ac8-b904-4fb4-bbbc-af53e2e360e2.png)