### PR TITLE
feat/refactor imageupload and change tilelayer

### DIFF
--- a/vue/package-lock.json
+++ b/vue/package-lock.json
@@ -1026,7 +1026,7 @@
     "defined": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
-      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
+      "integrity": "sha512-Y2caI5+ZwS5c3RiNDJ6u53VhQHv+hHKwhkI1iHvceKUHw9Df6EK2zRLfjejRgMuCuxK7PfSWIMwWecceVvThjQ==",
       "dev": true
     },
     "delayed-stream": {
@@ -2617,7 +2617,7 @@
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
     },
     "tinypool": {
@@ -3008,7 +3008,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
     },
     "ws": {

--- a/vue/src/App.vue
+++ b/vue/src/App.vue
@@ -1,15 +1,18 @@
 <template>
-  <q-layout view="lHh lpr lFf" class="h-full">
-    <div class="relative h-full">
-      <div class="row flex justify-between h-full">
-        <!--items-start-->
-        <router-view name="sidebar"></router-view>
-        <main class="flex flex-col w-full">
-          <router-view></router-view>
-        </main>
-      </div>
-    </div>
-  </q-layout>
+  <!-- <q-layout view="lHh lpr lFf" class="h-full"> -->
+  <!-- <div class="relative h-full"> -->
+  <!-- <div class="row flex justify-between h-full"> -->
+  <!--items-start-->
+  <div class="flex flex-row h-full flex-nowrap">
+    <router-view name="sidebar"></router-view>
+    <main class="flex flex-col flex-1 w-full h-full">
+      <router-view></router-view>
+    </main>
+  </div>
+
+  <!-- </div> -->
+  <!-- </div> -->
+  <!-- </q-layout> -->
 </template>
 
 <script setup lang="ts">

--- a/vue/src/components/BaseMap.vue
+++ b/vue/src/components/BaseMap.vue
@@ -13,14 +13,16 @@
 
 <template>
   <!-- <q-card class="w-full h-full shadow-1 bg-white"> -->
-  <div class="card-map w-full h-full">
+  <div class="card-map w-full h-full select-none">
     <leaflet-comp
       :maxZoom="maxZoom"
       :zoom="zoom"
       :map-image="mapImage"
       :zoom-control="zoomControl"
+      :map-interaction="mapInteraction"
       ref="leafletRef"
-    ></leaflet-comp>
+    >
+    </leaflet-comp>
   </div>
   <!-- </q-card> -->
 </template>
@@ -34,17 +36,13 @@ import type { LeafletEvent } from "leaflet";
 
 const leafletRef = ref<InstanceType<typeof LeafletComp> | null>(null);
 
-withDefaults(
-  defineProps<{
-    mapImage: MapImage;
-    maxZoom?: number;
-    zoom?: number;
-    zoomControl?: boolean;
-  }>(),
-  {
-    zoomControl: true,
-  }
-);
+defineProps<{
+  mapImage: MapImage;
+  maxZoom?: number;
+  zoom?: number;
+  zoomControl?: boolean;
+  mapInteraction?: boolean;
+}>();
 
 const emit = defineEmits<{
   (event: "markerClick", marker: L.Marker): void;

--- a/vue/src/components/BaseMap.vue
+++ b/vue/src/components/BaseMap.vue
@@ -34,12 +34,17 @@ import type { LeafletEvent } from "leaflet";
 
 const leafletRef = ref<InstanceType<typeof LeafletComp> | null>(null);
 
-defineProps<{
-  maxZoom?: number;
-  zoom?: number;
-  zoomControl?: boolean;
-  mapImage: MapImage;
-}>();
+withDefaults(
+  defineProps<{
+    mapImage: MapImage;
+    maxZoom?: number;
+    zoom?: number;
+    zoomControl?: boolean;
+  }>(),
+  {
+    zoomControl: true,
+  }
+);
 
 const emit = defineEmits<{
   (event: "markerClick", marker: L.Marker): void;

--- a/vue/src/components/CropsMap.vue
+++ b/vue/src/components/CropsMap.vue
@@ -1,9 +1,11 @@
 <!--everything in this comp is for testing only-->
 <template>
   <base-map
+    ref="baseMapRef"
     :map-image="mapImage"
     :zoom="20.5"
-    ref="baseMapRef"
+    :zoom-control="true"
+    :map-interaction="false"
     @polygon-enter="polygonEnter"
     @polygon-leave="polygonLeave"
   ></base-map>

--- a/vue/src/components/CropsMap.vue
+++ b/vue/src/components/CropsMap.vue
@@ -13,9 +13,9 @@ const baseMapRef = ref<InstanceType<typeof BaseMap> | null>(null);
 
 const mapImage: MapImage = {
   src: "https://cloud.naturerobots.de/apps/files_sharing/publicpreview/xZj9ytRt8WKr5cw?file=/goeoentueuegs_ibbenbueren_new2.jpg&fileId=28565&x=1920&y=1080&a=true",
-  top_left: new LatLng(52.31703002877383, 7.6307445019483575),
-  top_right: new LatLng(52.316885520295315, 7.630280744986272),
-  bottom_left: new LatLng(52.31721038577891, 7.630586922168733),
+  top_right: new LatLng(52.31724604719058, 7.630553394556046),
+  top_left: new LatLng(52.3170773725588, 7.630054503679276),
+  bottom_left: new LatLng(52.31686606722232, 7.630242593586445),
 };
 
 onMounted(() => {

--- a/vue/src/components/GardenMap.vue
+++ b/vue/src/components/GardenMap.vue
@@ -37,9 +37,9 @@ defineExpose({
 
 const mapImage: MapImage = {
   src: "https://cloud.naturerobots.de/apps/files_sharing/publicpreview/xZj9ytRt8WKr5cw?file=/goeoentueuegs_ibbenbueren_new2.jpg&fileId=28565&x=1920&y=1080&a=true",
-  top_right: new LatLng(52.31724405852429, 7.6305786972487475),
-  top_left: new LatLng(52.317090996655104, 7.630103431682726),
-  bottom_left: new LatLng(52.3168784640098, 7.630269296175566),
+  top_right: new LatLng(52.31724604719058, 7.630553394556046),
+  top_left: new LatLng(52.3170773725588, 7.630054503679276),
+  bottom_left: new LatLng(52.31686606722232, 7.630242593586445),
 };
 
 onMounted(() => {

--- a/vue/src/components/GardenMap.vue
+++ b/vue/src/components/GardenMap.vue
@@ -1,9 +1,11 @@
 <!--image is for testing only-->
 <template>
   <base-map
+    ref="baseMapRef"
     :map-image="mapImage"
     :zoom="20.5"
-    ref="baseMapRef"
+    :zoom-control="true"
+    :map-interaction="false"
     @marker-click="markerClick"
     @marker-enter="markerEnter"
     @marker-leave="markerLeave"

--- a/vue/src/components/ImageCropQuasar.vue
+++ b/vue/src/components/ImageCropQuasar.vue
@@ -1,19 +1,18 @@
 <template>
-  <div class="inline-flex space-x-3 pl-2 items-center">
-    <div class="q-pa-md">
-      <div class="q-gutter-y-md column" style="max-width: 300px">
-        <q-file
-          clearable
-          filled
-          v-model="model"
-          label="Image upload"
-          accept=".jpg, image/*"
-          @rejected="onRejected"
-          @clear="clearImg"
-          @update:model-value="setBase64($event)"
-        />
-      </div>
+  <div class="inline-flex space-x-3 pl-2 items-center q-pa-md">
+    <div class="q-gutter-y-md column" style="max-width: 300px">
+      <q-file
+        clearable
+        filled
+        v-model="model"
+        label="Image upload"
+        accept=".jpg, image/*"
+        @rejected="onRejected"
+        @clear="clearImg"
+        @update:model-value="setBase64($event)"
+      />
     </div>
+
     <div v-if="base64">
       <q-btn rounded color="primary" label="Crop Image" @click="crop" />
     </div>
@@ -22,7 +21,7 @@
     </div>
   </div>
 
-  <div class="grid grid-cols-2 p-6 gap-4">
+  <div class="grid grid-cols-2 p-6 gap-4 flex-1">
     <div v-if="base64" class="card bg-white">
       <div class="card-body">
         <cropper ref="cropperChild" class="cropper" :src="base64" />

--- a/vue/src/components/SidebarMenuQuasar.vue
+++ b/vue/src/components/SidebarMenuQuasar.vue
@@ -1,5 +1,8 @@
 <template>
-  <div class="fixed w-28 h-full z-10 bg-background shadow-2">
+  <div
+    class="w-28 sticky h-full bg-background shadow-2 flex-none"
+    style="min-height: 535px"
+  >
     <div class="text-center">
       <router-link :to="'/dashboard'">
         <img src="@/assets/img/logo_small_white.svg" class="p-6 pb-9" />

--- a/vue/src/components/header/HeaderBar.vue
+++ b/vue/src/components/header/HeaderBar.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="px-6 py-3 border-b">
-    <div class="pl-3 py-3 h-16 w-full flex items-center justify-between">
+  <div class="px-6 py-3 border-b flex-none w-full">
+    <div class="pl-3 py-3 h-16 flex items-center justify-between">
       <div class="text-3xl text-black">
         <div>{{ title }}</div>
       </div>

--- a/vue/src/components/leaflet/LeafletComp.vue
+++ b/vue/src/components/leaflet/LeafletComp.vue
@@ -15,10 +15,10 @@ let leafletMap: L.Map;
 
 const props = withDefaults(
   defineProps<{
-    maxZoom: number;
-    zoom: number;
     mapImage: MapImage;
-    zoomControl: boolean;
+    maxZoom?: number;
+    zoom?: number;
+    zoomControl?: boolean;
   }>(),
   {
     maxZoom: 24,
@@ -36,16 +36,39 @@ defineExpose({
 
 onMounted(() => {
   leafletMap = L.map("map", {
-    zoomControl: props.zoomControl,
+    zoomControl: false,
     attributionControl: false,
     zoomDelta: 0.25,
     zoomSnap: 0.25,
   });
 
-  L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
-    maxNativeZoom: 18,
-    maxZoom: props.maxZoom,
-  }).addTo(leafletMap);
+  //https://stackoverflow.com/a/55767702
+  if (props.zoomControl) {
+    L.control
+      .zoom({
+        position: "bottomright",
+      })
+      .addTo(leafletMap);
+  }
+
+  //Disable map interaction, can be removed later but for now it reduces the number of tiles that need to be downloaded.
+  leafletMap.dragging.disable();
+  leafletMap.touchZoom.disable();
+  leafletMap.doubleClickZoom.disable();
+  leafletMap.scrollWheelZoom.disable();
+  leafletMap.boxZoom.disable();
+  leafletMap.keyboard.disable();
+  if (leafletMap.tap) leafletMap.tap.disable();
+
+  //TODO: refactor params
+  L.tileLayer(
+    "https://api.mapbox.com/styles/v1/mapbox/satellite-streets-v9/tiles/{z}/{x}/{y}?access_token=pk.eyJ1IjoibHNpZWJlbHMiLCJhIjoiY2wxdno3d2E0Mnh4ZDNqcXJzbHlqeWZoMCJ9.KXbrKH7ESK2qu28olSw6sQ",
+    {
+      maxNativeZoom: 19,
+      minZoom: 19,
+      maxZoom: props.maxZoom,
+    }
+  ).addTo(leafletMap);
 
   if (props.mapImage) {
     let overlay = L.imageOverlay.rotated(

--- a/vue/src/components/leaflet/LeafletComp.vue
+++ b/vue/src/components/leaflet/LeafletComp.vue
@@ -19,11 +19,13 @@ const props = withDefaults(
     maxZoom?: number;
     zoom?: number;
     zoomControl?: boolean;
+    mapInteraction?: boolean;
   }>(),
   {
     maxZoom: 24,
     zoom: 13,
-    zoomControl: true,
+    //Disabled map interaction per default, can be fixed later but for now it reduces the number of tiles that need to be downloaded.
+    mapInteraction: false,
   }
 );
 
@@ -36,29 +38,33 @@ defineExpose({
 
 onMounted(() => {
   leafletMap = L.map("map", {
-    zoomControl: false,
-    attributionControl: false,
-    zoomDelta: 0.25,
-    zoomSnap: 0.25,
+    ...{
+      zoomControl: false,
+      attributionControl: false,
+      zoomDelta: 0.25,
+      zoomSnap: 0.25,
+    },
+    ...(props.mapInteraction
+      ? {}
+      : {
+          dragging: false,
+          touchZoom: false,
+          doubleClickZoom: false,
+          scrollWheelZoom: false,
+          boxZoom: false,
+          keyboard: false,
+          tap: false,
+        }),
   });
 
   //https://stackoverflow.com/a/55767702
   if (props.zoomControl) {
     L.control
       .zoom({
-        position: "bottomright",
+        position: "topright",
       })
       .addTo(leafletMap);
   }
-
-  //Disable map interaction, can be removed later but for now it reduces the number of tiles that need to be downloaded.
-  leafletMap.dragging.disable();
-  leafletMap.touchZoom.disable();
-  leafletMap.doubleClickZoom.disable();
-  leafletMap.scrollWheelZoom.disable();
-  leafletMap.boxZoom.disable();
-  leafletMap.keyboard.disable();
-  if (leafletMap.tap) leafletMap.tap.disable();
 
   //TODO: refactor params
   L.tileLayer(

--- a/vue/src/components/leaflet/LeafletRotatedComp.vue
+++ b/vue/src/components/leaflet/LeafletRotatedComp.vue
@@ -1,24 +1,51 @@
 <template>
-  <div class="map-container">
-    <div id="map"></div>
+  <div class="inline-flex space-x-3 pl-2 items-center q-pa-md">
+    <q-btn rounded color="primary" label="Save Image" @click="saveImage" />
+    <q-btn
+      v-if="markers.length == 3 && parseFloat(opacity.toFixed(1)) >= 0.1"
+      rounded
+      color="black font-bold"
+      fab-mini
+      label="-"
+      @click="updateOpacity(-0.1)"
+    />
+    <q-btn
+      v-if="markers.length == 3 && parseFloat(opacity.toFixed(1)) <= 0.9"
+      rounded
+      color="black font-bold"
+      fab-mini
+      label="+"
+      @click="updateOpacity(0.1)"
+    />
   </div>
-  <button class="btn btn-primary mt-3" @click="saveImage">Save</button>
+
+  <div class="card-map h-full m-4 flex-1">
+    <div class="map-container w-full h-full">
+      <div id="map"></div>
+    </div>
+  </div>
 </template>
 
 <script setup lang="ts">
-import { onMounted } from "vue";
+import { onMounted, ref } from "vue";
 import { useRouter, useRoute } from "vue-router";
-import L, { type LeafletMouseEvent } from "leaflet";
+import L from "leaflet";
+import type { LeafletMouseEvent } from "leaflet";
+import { useQuasar } from "quasar";
+import type { QVueGlobals } from "quasar";
 import "leaflet/dist/leaflet.css";
 import "./LeafletRotation.ts";
 
 const router = useRouter();
 const route = useRoute();
-const markers: L.Marker[] = [];
+const markers = ref<L.Marker[]>([]);
+
+const $q: QVueGlobals = useQuasar();
 
 let leafletMap: L.Map;
 let overlay: L.ImageOverlay.Rotated;
 let counter = 0;
+let opacity = ref<number>(0.5);
 
 const greenIcon: L.Icon = new L.Icon({
   iconUrl: "src/assets/marker/marker_green.svg",
@@ -28,26 +55,54 @@ const greenIcon: L.Icon = new L.Icon({
 });
 
 onMounted(() => {
+  if (!route.params.src) {
+    $q.notify({
+      type: "negative",
+      message: "No image selected!",
+    });
+    router.push({ path: "/cropimage" });
+  }
+
+  //TODO: Get coords from stored location
   leafletMap = L.map("map", { zoomControl: false }).setView(
-    new L.LatLng(52.27264, 8.0498),
+    new L.LatLng(52.317033021766406, 7.630251717595675),
     13
   );
 
-  L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
-    maxNativeZoom: 18,
-    maxZoom: 24,
-  }).addTo(leafletMap);
+  //TODO: refactor params
+  L.tileLayer(
+    "https://api.mapbox.com/styles/v1/mapbox/satellite-streets-v9/tiles/{z}/{x}/{y}?access_token=pk.eyJ1IjoibHNpZWJlbHMiLCJhIjoiY2wxdno3d2E0Mnh4ZDNqcXJzbHlqeWZoMCJ9.KXbrKH7ESK2qu28olSw6sQ",
+    {
+      maxNativeZoom: 18,
+      minZoom: 18,
+      maxZoom: 22,
+    }
+  ).addTo(leafletMap);
 
   leafletMap.on("click", setMarker);
 });
 
 function repositionImage() {
-  if (markers.length == 3) {
+  if (markers.value.length == 3) {
     overlay.reposition(
-      markers[0].getLatLng(),
-      markers[1].getLatLng(),
-      markers[2].getLatLng()
+      markers.value[0].getLatLng(),
+      markers.value[1].getLatLng(),
+      markers.value[2].getLatLng()
     );
+  }
+
+  console.log(markers.value.map((value) => value?.getLatLng()));
+}
+
+function updateOpacity(opacityFactor: number) {
+  opacity.value += opacityFactor;
+  console.log(opacity.value.toFixed(1));
+  if (
+    markers.value.length == 3 &&
+    parseFloat(opacity.value.toFixed(1)) >= 0.0 &&
+    parseFloat(opacity.value.toFixed(1)) <= 1.0
+  ) {
+    overlay.updateOpacity(opacity.value);
   }
 }
 
@@ -59,7 +114,7 @@ function setMarker(e: LeafletMouseEvent): void {
       icon: greenIcon,
     }).addTo(leafletMap);
 
-    markers.push(marker);
+    markers.value.push(marker);
     marker.on("drag dragend", repositionImage);
 
     counter += 1;
@@ -72,11 +127,11 @@ function setMarker(e: LeafletMouseEvent): void {
 function setImage(): void {
   overlay = L.imageOverlay.rotated(
     route.params.src,
-    markers[0].getLatLng(),
-    markers[1].getLatLng(),
-    markers[2].getLatLng(),
+    markers.value[0].getLatLng(),
+    markers.value[1].getLatLng(),
+    markers.value[2].getLatLng(),
     {
-      opacity: 1,
+      opacity: opacity.value,
       interactive: true,
     }
   );
@@ -90,13 +145,3 @@ function saveImage(): void {
   router.push({ path: "/dashboard" });
 }
 </script>
-
-<style>
-.map-container {
-  width: 100%;
-}
-#map {
-  height: 600px;
-  width: 100%;
-}
-</style>

--- a/vue/src/components/leaflet/LeafletRotation.ts
+++ b/vue/src/components/leaflet/LeafletRotation.ts
@@ -1,4 +1,5 @@
 import L from "leaflet";
+
 L.ImageOverlay.Rotated = L.ImageOverlay.extend({
   initialize: function (image, topleft, topright, bottomleft, options) {
     if (typeof image === "string") {
@@ -103,6 +104,7 @@ L.ImageOverlay.Rotated = L.ImageOverlay.extend({
       pxBottomLeft,
       pxBottomRight,
     ]);
+
     const size = pxBounds.getSize();
     const pxTopLeftInDiv = pxTopLeft.subtract(pxBounds.min);
 
@@ -155,7 +157,12 @@ L.ImageOverlay.Rotated = L.ImageOverlay.extend({
     this._topLeft = L.latLng(topleft);
     this._topRight = L.latLng(topright);
     this._bottomLeft = L.latLng(bottomleft);
+
     this._reset();
+  },
+
+  updateOpacity: function (opacity: number) {
+    if (opacity >= 0 && opacity <= 1) this._image.style.opacity = opacity;
   },
 
   //TODO: Explicit Types?

--- a/vue/src/views/CropImageView.vue
+++ b/vue/src/views/CropImageView.vue
@@ -1,13 +1,11 @@
 <template>
-  <div class="ml-28">
+  <div class="flex-nowrap">
     <header-bar title="Crop Image"></header-bar>
-    <!-- <image-crop></image-crop> -->
     <image-crop-quasar></image-crop-quasar>
   </div>
 </template>
 
 <script setup lang="ts">
 import HeaderBar from "@/components/header/HeaderBar.vue";
-//import ImageCrop from "@/components/ImageCrop.vue";
 import ImageCropQuasar from "@/components/ImageCropQuasar.vue";
 </script>

--- a/vue/src/views/Crops3dView.vue
+++ b/vue/src/views/Crops3dView.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="ml-28">
+  <div class="flex-nowrap">
     <header-bar
       title="3D"
       :widgetOptions="widgetOptions3D"

--- a/vue/src/views/CropsView.vue
+++ b/vue/src/views/CropsView.vue
@@ -1,13 +1,5 @@
-<!-- <template>
-  <header-bar title="Crops"></header-bar>
-  <div class="p-6"></div>
-</template> -->
-
 <template>
-  <!-- <div class="px-3 py-5 text-h2 text-primary_hover">
-    Crops
-  </div> -->
-  <div class="ml-28">
+  <div class="flex-nowrap">
     <header-bar
       title="Crops"
       :widgetOptions="widgetOptionsCrops"

--- a/vue/src/views/DashboardView.vue
+++ b/vue/src/views/DashboardView.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="ml-28">
+  <div class="flex-nowrap">
     <header-bar
       title="Dashboard"
       :widgetOptions="widgetOptionsDashboard"
@@ -33,6 +33,7 @@
       </div>
     </div>
   </div>
+
   <!-- DEMO LAYOUTS -->
   <!-- <div class="grid grid-cols-3 gap-4 place-items-stretch h-fit p-3">
     <div>
@@ -69,7 +70,8 @@
 </template>
 
 <script setup lang="ts">
-import { ref, type Ref } from "vue";
+import { ref } from "vue";
+import type { Ref } from "vue";
 import { storeToRefs } from "pinia";
 import { sensorStore } from "@/stores/sensorStore";
 import { userStore } from "@/stores/userStore";

--- a/vue/src/views/ImageUploadView.vue
+++ b/vue/src/views/ImageUploadView.vue
@@ -1,9 +1,9 @@
 <template>
-  <div class="ml-28">
-    <leaflet-rotated-comp></leaflet-rotated-comp>
-  </div>
+  <header-bar title="Place Image"></header-bar>
+  <leaflet-rotated-comp></leaflet-rotated-comp>
 </template>
 
 <script setup lang="ts">
+import HeaderBar from "@/components/header/HeaderBar.vue";
 import LeafletRotatedComp from "@/components/leaflet/LeafletRotatedComp.vue";
 </script>


### PR DESCRIPTION
- For a better representation of the map, the [Static Tiles API](https://docs.mapbox.com/api/maps/static-tiles/?utm_source=mapboxcom&utm_medium=pricing#static-tiles-api-pricing) with the satellite style of Mapbox is now used. 
❗❗❗ Interaction with the basic maps is disabled except for zooming with the buttons to reduce the number of tiles that are loaded. (must be optimised) ❗❗❗
- Improved the placement of the previously cropped image. The image can now be arranged more easily because of the satellite style and the transparency of the image can be adjusted to provide the most accurate manual placement possible.
![2022-06-27_13h49_45](https://user-images.githubusercontent.com/57572111/175935597-34518241-96be-49a0-a835-4fb870f56eaf.png) 
-  First revision of the Basic CSS layout. 
❗ This needs to be worked on in a separate issue, because the pages are still not really responsive.

