### PR TITLE
docs/env variables and modes

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,7 +18,8 @@
     "vue.volar",
     "vue.vscode-typescript-vue-plugin",
     "davidanson.vscode-markdownlint",
-    "gruntfuggly.todo-tree"
+    "gruntfuggly.todo-tree",
+    "yzhang.markdown-all-in-one"
   ],
   "workspaceFolder": "/workdir",
   "postStartCommand": ".devcontainer/post-create-setup.sh"

--- a/.mdl_style.rb
+++ b/.mdl_style.rb
@@ -5,7 +5,7 @@ all
 exclude_rule 'fenced-code-language' # Fenced code blocks should have a language specified
 exclude_rule 'no-inline-html' # This rule is triggered whenever raw HTML is used in a markdown document:
 
-#Excluded to work with mkdocs material superfences. Not a nice solution.
+#Excluded to work with mkdocs material superfences.
 exclude_rule 'MD046'
 exclude_rule 'MD009'
 

--- a/.mdl_style.rb
+++ b/.mdl_style.rb
@@ -5,6 +5,9 @@ all
 exclude_rule 'fenced-code-language' # Fenced code blocks should have a language specified
 exclude_rule 'no-inline-html' # This rule is triggered whenever raw HTML is used in a markdown document:
 
+#Excluded to work with mkdocs material superfences. Not a nice solution.
+exclude_rule 'MD046'
+exclude_rule 'MD009'
 
 # Line lenght
 rule 'MD013', :line_length => 120, :code_blocks => false, :tables => false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,8 @@ repos:
               .*\.obj|
               .*\.pgm|
               .*\.step|
-              .*\.stl
+              .*\.stl|
+              .*\.md
           )$
       - id: fix-byte-order-marker
       - id: mixed-line-ending

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+# Ignore all MD files:
+*.md

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,16 @@ demo-post:
 run-frontend:
 	@cd vue && npm run dev
 
+run-frontend-prod:
+	@echo "#############################"
+	@echo "# build vite for production #"
+	@echo "#############################"
+	@cd vue && npm run build
+	@echo "##########################"
+	@echo "# run vite in production #"
+	@echo "##########################"
+	@cd vue && npm run preview
+
 start-mkdocs:
 	@mkdocs serve
 

--- a/docs/vite-env-vars-modes.md
+++ b/docs/vite-env-vars-modes.md
@@ -1,0 +1,101 @@
+# Vite Env Variables and Modes
+
+The `Vite` documentation for `Env Variables and Modes` is available _[here](https://vitejs.dev/guide/env-and-mode.html#env-variables-and-modes)_.
+
+## Modes
+
+### Development Mode
+
+```bash
+# run vite in development mode
+cd vue
+npm run dev
+# or
+make run-frontend
+```
+
+### Production Mode
+
+```bash
+# run vite in production mode
+cd vue
+npm run build
+npm run preview
+# or
+make run-frontend-prod
+```
+
+## Environment
+
+### Files
+
+<!--python only added for syntax highlighting, would be text-->
+
+```python
+.env              # loaded in all cases
+.env.development  # only loaded in development mode
+.env.production   # only loaded in production mode
+```
+
+!!! danger
+    **❗ Do not store sensitive information in `.env` files. ❗**
+    Sensitive variables can be stored in `.env.*.local` files by adding it to your .gitignore to avoid them being
+    checked into git.
+
+▶ [Detailed information](https://vitejs.dev/guide/env-and-mode.html#env-files)
+
+### Variables
+
+| Variable           | Description                                                       | default     | dev            | prod            |
+| ------------------ | ----------------------------------------------------------------- | ----------- | -------------- | --------------- |
+| VITE_APP_TITLE     | Title of the app in specific mode                                 | PlantMap    | [DEV] PlantMap | [PROD] PlantMap |
+| VITE_AUTH_REQUIRED | false/true, if auth is requried                                   | false       | false          | true            |
+| VITE_TOKEN_MAPBOX  | [Mapbox](<[https://](https://www.mapbox.com/)>) token             | must be set | /              | /               |
+| VITE_TOKEN_OWM     | [OpenWeatherMap](<[https://](https://openweathermap.org/)>) token | must be set | /              | /               |
+
+!!! info
+    An env file for a specific mode (e.g. .env.production) will take higher priority than the generic `.env`.
+    Environment variables that already exist when Vite is executed have the highest priority and will not be
+    overwritten by `.env` files.
+
+<!--bash only added for syntax highlighting, would be text-->
+
+```bash
+# vue/.env
+VITE_APP_TITLE=PlantMap
+VITE_AUTH_REQUIRED=false
+VITE_TOKEN_MAPBOX= ... #SET TOKEN
+VITE_TOKEN_OWM= ... #SET TOKEN
+
+# vue/.env.development
+VITE_APP_TITLE=[DEV] PlantMap
+VITE_AUTH_REQUIRED=false
+
+# vue/.env.production
+VITE_APP_TITLE=[PROD] PlantMap
+VITE_AUTH_REQUIRED=true
+```
+
+## IntelliSense for TypeScript
+
+```TypeScript
+// vue/env.d.ts
+
+interface ImportMetaEnv {
+  readonly VITE_APP_TITLE: string;
+  readonly VITE_AUTH_REQUIRED: string; //should be a boolean ❗
+  readonly VITE_TOKEN_MAPBOX: string;
+  readonly VITE_TOKEN_OWM: string;
+}
+```
+
+<!--FIXME: MD046 can be ignored, but maybe add markdownlint config for that?-->
+
+??? Bug
+    The type of `VITE_AUTH_REQUIRED` should be a boolean, but if the type is set to boolean,
+    `VITE_AUTH_REQUIRED` remains a string.
+
+    ```diff
+    - readonly VITE_AUTH_REQUIRED: string;
+    + readonly VITE_AUTH_REQUIRED: boolean;
+    ```

--- a/docs/vite-env-vars-modes.md
+++ b/docs/vite-env-vars-modes.md
@@ -38,7 +38,7 @@ make run-frontend-prod
 ```
 
 !!! danger
-    **❗ Do not store sensitive information in `.env` files. ❗**
+    **❗ Do not store sensitive information in `.env` files. ❗**  
     Sensitive variables can be stored in `.env.*.local` files by adding it to your .gitignore to avoid them being
     checked into git.
 
@@ -88,8 +88,6 @@ interface ImportMetaEnv {
   readonly VITE_TOKEN_OWM: string;
 }
 ```
-
-<!--FIXME: MD046 can be ignored, but maybe add markdownlint config for that?-->
 
 ??? Bug
     The type of `VITE_AUTH_REQUIRED` should be a boolean, but if the type is set to boolean,

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,7 @@ extra_css:
   - stylesheets/extra.css
 markdown_extensions:
   - admonition
+  - pymdownx.details
   - pymdownx.highlight:
       anchor_linenums: true
   - pymdownx.superfences

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,6 +8,7 @@ nav:
   - Reference:
       - Definitions: definitions.md
       - Authentication: authentication.md
+      - Vite Env Variables and Modes: vite-env-vars-modes.md
 theme:
   name: material
   language: en
@@ -28,3 +29,13 @@ markdown_extensions:
   - pymdownx.superfences
   - meta
   - attr_list
+  - toc:
+      permalink: "#"
+  - pymdownx.striphtml:
+      strip_comments: true #default
+  # TODO: Add mermaid for graphs?
+  #- pymdownx.superfences:
+  #    custom_fences:
+  #      - name: mermaid
+  #        class: mermaid
+  #        format: !!python/name:pymdownx.superfences.fence_code_format

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,9 +34,3 @@ markdown_extensions:
       permalink: "#"
   - pymdownx.striphtml:
       strip_comments: true #default
-  # TODO: Add mermaid for graphs?
-  #- pymdownx.superfences:
-  #    custom_fences:
-  #      - name: mermaid
-  #        class: mermaid
-  #        format: !!python/name:pymdownx.superfences.fence_code_format


### PR DESCRIPTION
- added make rule `run-frontend-prod` to run frontend in production mode
- added vsc md extension [Markdown All in One](https://marketplace.visualstudio.com/items?itemName=yzhang.markdown-all-in-one), has some nice features
- added markdown extensions
      - `toc`: adds a permalink next to the headings, which becomes visible when hovering over it.
         ![image](https://user-images.githubusercontent.com/57572111/176547060-aec84238-78be-4fb2-b46e-ecf0159bb780.png)
      - `pymdownx.striphtml`: ignores HTML comments, so these comments are not present in the rendered page.
      -  `pymdownx.details`: needed for collapsible elements

I had to make a few adjustments in the pre-commits checks so that I could work reasonably with superfences, because markdownlinter and mkdocs don't like each other. 🙃
@jarkenau Could you please check if this is OK or if you could at least adjust the pre-commit config better so that not all `.md ` files are affected.

... and finally the actual documentation for vite env variables and mode. 🚀