### PR TITLE
feat: user creation now takes first and last name

### DIFF
--- a/django/restapi/models.py
+++ b/django/restapi/models.py
@@ -7,23 +7,28 @@ from django.contrib.auth.models import User
 from django.db import models
 
 
-class CreateUserSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = User
-        fields = ['username', 'password']
-        extra_kwargs = {'password': {'write_only': True}}
-
-    def create(self, validated_data):
-        user = User(username=validated_data['username'])
-        user.set_password(validated_data['password'])
-        user.save()
-        return user
-
-
 class UserSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
-        fields = '__all__'
+        fields = ['username', 'password', 'first_name', 'last_name', 'date_joined', 'last_login']
+        # fields = '__all__'
+        extra_kwargs = {
+            'password': {'write_only': True},
+            'first_name': {'required': True},
+            'last_name': {'required': True},
+            'last_login': {'read_only': True},
+            'date_joined': {'read_only': True},
+        }
+
+    def create(self, validated_data):
+        user = User(
+            username=validated_data['username'],
+            first_name=validated_data['first_name'],
+            last_name=validated_data['last_name'],
+        )
+        user.set_password(validated_data['password'])
+        user.save()
+        return user
 
 
 class Company(models.Model):

--- a/django/restapi/views.py
+++ b/django/restapi/views.py
@@ -63,7 +63,7 @@ class RegisterView(KnoxLoginView):
     permission_classes = (permissions.AllowAny,)
 
     def post(self, request, format=None):
-        serializer = CreateUserSerializer(data=request.data)
+        serializer = UserSerializer(data=request.data)
         if serializer.is_valid():
             serializer.save()
             authserializer = AuthTokenSerializer(data=request.data)

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -27,15 +27,41 @@ Example response:
 
 ### `/register`
 
-Requests and responses are the same as for `/login`,
-but a new user is created with the provided username & password
+Responses are the same as for `/login`,
+but requests need to supply a `first_name` and a `last_name` as well.
+A new user is created with the provided information
 and an error is returned if the username is already taken.
+
+```json
+{
+ "username": "testuser1234",
+ "password": "7Gq^7Mjwgi%#DcHj22$C",
+ "first_name": "first",
+ "last_name": "last"
+}
+```
 
 ### `/logout` & `/logoutall`
 
 These endpoints take an empty POST request.
 With `/logout` the logged in user is logged out from the current session,
 with `/logoutall` from all sessions.
+
+### `/user`
+
+An empty GET request returns information about the currently logged in user.
+
+Example response:
+
+```json
+{
+ "username": "testuser1234",
+ "first_name": "first",
+ "last_name": "last",
+ "date_joined": "2022-07-12T12:49:31.010300Z",
+ "last_login": "2022-07-19T11:35:55.158069Z"
+}
+```
 
 ## Token
 


### PR DESCRIPTION
Additionally, more info is returned when querying the user.
User creation object:
```json
{
	"username": "testuser1234",
	"password": "7Gq^7Mjwgi%#DcHj22$C"
	"first_name": "first",
	"last_name": "last"
}
```
User info returned when querying:
```json
{
	"username": "testuser1234",
	"first_name": "first",
	"last_name": "last",
	"date_joined": "2022-07-12T12:49:31.010300Z",
	"last_login": "2022-07-19T11:35:55.158069Z"
}
```

fixes #169